### PR TITLE
Fix for disabled lesshint linter and deprecation warnings in current version of sublimelinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,6 @@ from SublimeLinter.lint import NodeLinter, util
 class Lesshint(NodeLinter):
     """Provides an interface to lesshint."""
 
-    syntax = 'less'
     cmd = 'lesshint @'
     executable = None
     version_args = '--version'
@@ -32,6 +31,8 @@ class Lesshint(NodeLinter):
     line_col_base = (1, 1)
     tempfile_suffix = 'less'
     error_stream = util.STREAM_BOTH
-    selectors = {}
+    defaults = {
+        selector': 'source.less'
+    }
     word_re = None
     defaults = {}


### PR DESCRIPTION
Actual SublimeLinter error messages:
```
lesshint: Defining 'cls.syntax' has no effect anymore.
lesshint: Defining 'cls.selectors' has no effect anymore.
lesshint disabled. 'selector' is mandatory in 'cls.defaults'.
See http://www.sublimelinter.com/en/stable/linter_settings.html#selector
```
using defaults selector with source.less should make lesshint work again
removing syntax and selectors should remove deprecation warnings