### PR TITLE
Fix for `lesshint disabled. 'selector' is mandatory in 'cls.defaults'.`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,11 +16,8 @@ from SublimeLinter.lint import NodeLinter, util
 class Lesshint(NodeLinter):
     """Provides an interface to lesshint."""
 
-    cmd = 'lesshint @'
-    executable = None
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 2.1.1'
+    name = 'lesshint'
+    cmd = ['lesshint', '--verbose', '${args}', '-']
     regex = (
         r'((?P<error>Error)|(?P<warning>Warning))+?:(?P<file>.+)'
         r': line (?P<line>\d+),'
@@ -29,10 +26,14 @@ class Lesshint(NodeLinter):
     )
     multiline = False
     line_col_base = (1, 1)
-    tempfile_suffix = 'less'
     error_stream = util.STREAM_BOTH
+    tempfile_suffix = 'less'
+
     defaults = {
         "selector": "source.less"
     }
-    word_re = None
-    defaults = {}
+
+    # the following attributes are marked useless for SL4
+    version_args = '--version'
+    version_re = r'(?P<version>\d+\.\d+\.\d+)'
+    version_requirement = '>= 2.1.1'


### PR DESCRIPTION
Fixes:

* https://github.com/jasjuang/SublimeLinter-contrib-lesshint/issues/10